### PR TITLE
Add pages for launching transactions, debts and assets

### DIFF
--- a/src/app/ativos/page.tsx
+++ b/src/app/ativos/page.tsx
@@ -1,3 +1,122 @@
+"use client"
+
+import { useState } from "react"
+import axios from "axios"
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
 export default function Page() {
-  return <div className="p-4">Ativos Page</div>
+  const [nome, setNome] = useState("")
+  const [tipo, setTipo] = useState<"imóvel" | "veículo" | "investimento" | "outro">("outro")
+  const [valorAtual, setValorAtual] = useState("")
+  const [dataAquisicao, setDataAquisicao] = useState("")
+  const [observacao, setObservacao] = useState("")
+
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState("")
+  const [message, setMessage] = useState("")
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setError("")
+    setMessage("")
+
+    if (!nome || !valorAtual || !dataAquisicao) {
+      setError("Preencha os campos obrigatórios")
+      return
+    }
+
+    setLoading(true)
+    try {
+      await axios.post("/api/assets", {
+        nome,
+        tipo,
+        valorAtual: parseFloat(valorAtual),
+        dataAquisicao: new Date(dataAquisicao),
+        historicoDeValores: [],
+        observacao,
+      })
+      setMessage("Ativo cadastrado com sucesso")
+      setNome("")
+      setValorAtual("")
+      setDataAquisicao("")
+      setObservacao("")
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        setError(err.response?.data?.error || "Erro ao cadastrar ativo")
+      } else {
+        setError("Erro inesperado")
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="p-4">
+      <Card className="mx-auto w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Lançar Ativo</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {error && <p className="mb-2 text-sm text-destructive">{error}</p>}
+          {message && <p className="mb-2 text-sm text-green-600">{message}</p>}
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <Input
+              placeholder="Nome"
+              value={nome}
+              onChange={(e) => setNome(e.target.value)}
+            />
+            <div>
+              <Label>Tipo</Label>
+              <select
+                className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
+                value={tipo}
+                onChange={(e) =>
+                  setTipo(e.target.value as "imóvel" | "veículo" | "investimento" | "outro")
+                }
+              >
+                <option value="imóvel">Imóvel</option>
+                <option value="veículo">Veículo</option>
+                <option value="investimento">Investimento</option>
+                <option value="outro">Outro</option>
+              </select>
+            </div>
+            <div>
+              <Label>Valor Atual</Label>
+              <Input
+                type="number"
+                value={valorAtual}
+                onChange={(e) => setValorAtual(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label>Data de Aquisição</Label>
+              <Input
+                type="date"
+                value={dataAquisicao}
+                onChange={(e) => setDataAquisicao(e.target.value)}
+              />
+            </div>
+            <Input
+              placeholder="Observação"
+              value={observacao}
+              onChange={(e) => setObservacao(e.target.value)}
+            />
+            <Button type="submit" className="w-full" disabled={loading}>
+              Salvar
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
 }

--- a/src/app/dividas/page.tsx
+++ b/src/app/dividas/page.tsx
@@ -1,3 +1,158 @@
+"use client"
+
+import { useState } from "react"
+import axios from "axios"
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
 export default function Page() {
-  return <div className="p-4">Dividas Page</div>
+  const [nome, setNome] = useState("")
+  const [valorOriginal, setValorOriginal] = useState("")
+  const [valorAtual, setValorAtual] = useState("")
+  const [juros, setJuros] = useState("")
+  const [dataContratacao, setDataContratacao] = useState("")
+  const [parcelasTotais, setParcelasTotais] = useState("")
+  const [parcelasPagas, setParcelasPagas] = useState("")
+  const [dataVencimentoProxima, setDataVencimentoProxima] = useState("")
+  const [observacao, setObservacao] = useState("")
+
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState("")
+  const [message, setMessage] = useState("")
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setError("")
+    setMessage("")
+
+    if (!nome || !valorOriginal || !valorAtual || !dataContratacao) {
+      setError("Preencha os campos obrigatórios")
+      return
+    }
+
+    setLoading(true)
+    try {
+      await axios.post("/api/debts", {
+        nome,
+        valorOriginal: parseFloat(valorOriginal),
+        valorAtual: parseFloat(valorAtual),
+        juros: juros ? parseFloat(juros) : undefined,
+        dataContratacao: new Date(dataContratacao),
+        parcelasTotais: Number(parcelasTotais || 0),
+        parcelasPagas: Number(parcelasPagas || 0),
+        dataVencimentoProxima: dataVencimentoProxima
+          ? new Date(dataVencimentoProxima)
+          : undefined,
+        observacao,
+        status: "ativa",
+      })
+      setMessage("Dívida cadastrada com sucesso")
+      setNome("")
+      setValorOriginal("")
+      setValorAtual("")
+      setJuros("")
+      setDataContratacao("")
+      setParcelasTotais("")
+      setParcelasPagas("")
+      setDataVencimentoProxima("")
+      setObservacao("")
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        setError(err.response?.data?.error || "Erro ao cadastrar dívida")
+      } else {
+        setError("Erro inesperado")
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="p-4">
+      <Card className="mx-auto w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Lançar Dívida</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {error && <p className="mb-2 text-sm text-destructive">{error}</p>}
+          {message && <p className="mb-2 text-sm text-green-600">{message}</p>}
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <Input
+              placeholder="Nome"
+              value={nome}
+              onChange={(e) => setNome(e.target.value)}
+            />
+            <div>
+              <Label>Valor Original</Label>
+              <Input
+                type="number"
+                value={valorOriginal}
+                onChange={(e) => setValorOriginal(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label>Valor Atual</Label>
+              <Input
+                type="number"
+                value={valorAtual}
+                onChange={(e) => setValorAtual(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label>Juros (%)</Label>
+              <Input
+                type="number"
+                value={juros}
+                onChange={(e) => setJuros(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label>Data de Contratação</Label>
+              <Input
+                type="date"
+                value={dataContratacao}
+                onChange={(e) => setDataContratacao(e.target.value)}
+              />
+            </div>
+            <Input
+              placeholder="Parcelas Totais"
+              type="number"
+              value={parcelasTotais}
+              onChange={(e) => setParcelasTotais(e.target.value)}
+            />
+            <Input
+              placeholder="Parcelas Pagas"
+              type="number"
+              value={parcelasPagas}
+              onChange={(e) => setParcelasPagas(e.target.value)}
+            />
+            <div>
+              <Label>Próximo Vencimento</Label>
+              <Input
+                type="date"
+                value={dataVencimentoProxima}
+                onChange={(e) => setDataVencimentoProxima(e.target.value)}
+              />
+            </div>
+            <Input
+              placeholder="Observação"
+              value={observacao}
+              onChange={(e) => setObservacao(e.target.value)}
+            />
+            <Button type="submit" className="w-full" disabled={loading}>
+              Salvar
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
 }

--- a/src/app/transacoes/page.tsx
+++ b/src/app/transacoes/page.tsx
@@ -1,3 +1,157 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import axios from "axios"
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+interface Categoria {
+  _id: string
+  nome: string
+  tipo: "receita" | "despesa"
+}
+
 export default function Page() {
-  return <div className="p-4">Transacoes Page</div>
+  const [valor, setValor] = useState("")
+  const [data, setData] = useState("")
+  const [tipo, setTipo] = useState<"receita" | "despesa">("despesa")
+  const [categoriaId, setCategoriaId] = useState("")
+  const [descricao, setDescricao] = useState("")
+  const [formaPagamento, setFormaPagamento] = useState("")
+
+  const [categorias, setCategorias] = useState<Categoria[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState("")
+  const [message, setMessage] = useState("")
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await axios.get("/api/categories")
+        setCategorias(res.data)
+      } catch {
+        // ignore erro ao carregar categorias
+      }
+    }
+    load()
+  }, [])
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setError("")
+    setMessage("")
+
+    if (!valor || !data || !categoriaId) {
+      setError("Preencha os campos obrigatórios")
+      return
+    }
+
+    setLoading(true)
+    try {
+      await axios.post("/api/transactions", {
+        valor: parseFloat(valor),
+        data: new Date(data),
+        tipo,
+        categoriaId,
+        descricao,
+        formaPagamento,
+        origem: "manual",
+      })
+      setMessage("Transação lançada com sucesso")
+      setValor("")
+      setData("")
+      setCategoriaId("")
+      setDescricao("")
+      setFormaPagamento("")
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        setError(err.response?.data?.error || "Erro ao lançar transação")
+      } else {
+        setError("Erro inesperado")
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="p-4">
+      <Card className="mx-auto w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Lançar Transação</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {error && <p className="mb-2 text-sm text-destructive">{error}</p>}
+          {message && <p className="mb-2 text-sm text-green-600">{message}</p>}
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <div>
+              <Label>Valor</Label>
+              <Input
+                type="number"
+                value={valor}
+                onChange={(e) => setValor(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label>Data</Label>
+              <Input
+                type="date"
+                value={data}
+                onChange={(e) => setData(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label>Tipo</Label>
+              <select
+                className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
+                value={tipo}
+                onChange={(e) => setTipo(e.target.value as "receita" | "despesa")}
+              >
+                <option value="despesa">Despesa</option>
+                <option value="receita">Receita</option>
+              </select>
+            </div>
+            <div>
+              <Label>Categoria</Label>
+              <select
+                className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
+                value={categoriaId}
+                onChange={(e) => setCategoriaId(e.target.value)}
+              >
+                <option value="">Selecione...</option>
+                {categorias
+                  .filter((c) => c.tipo === tipo)
+                  .map((c) => (
+                    <option key={c._id} value={c._id}>
+                      {c.nome}
+                    </option>
+                  ))}
+              </select>
+            </div>
+            <Input
+              placeholder="Descrição"
+              value={descricao}
+              onChange={(e) => setDescricao(e.target.value)}
+            />
+            <Input
+              placeholder="Forma de pagamento"
+              value={formaPagamento}
+              onChange={(e) => setFormaPagamento(e.target.value)}
+            />
+            <Button type="submit" className="w-full" disabled={loading}>
+              Lançar
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- implement transaction creation form
- implement asset creation form
- implement debt creation form

## Testing
- `npm run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_6842558d1c088320b626857f02de7a6a