### PR TITLE
Implement responsive dark mode with theme toggle

### DIFF
--- a/src/app/ativos/page.tsx
+++ b/src/app/ativos/page.tsx
@@ -78,10 +78,12 @@ export default function Page() {
             <div>
               <Label>Tipo</Label>
               <select
-                className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
+                className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm dark:bg-background dark:text-foreground"
                 value={tipo}
                 onChange={(e) =>
-                  setTipo(e.target.value as "imóvel" | "veículo" | "investimento" | "outro")
+                  setTipo(
+                    e.target.value as 'imóvel' | 'veículo' | 'investimento' | 'outro'
+                  )
                 }
               >
                 <option value="imóvel">Imóvel</option>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,7 +12,7 @@
     --foreground: #ededed;
   }
   body {
-    @apply bg-[color:var(--background)] text-[color:var(--foreground)];
+    @apply bg-[color:var(--background)] text-[color:var(--foreground)] transition-colors;
     font-family: var(--font-inter), sans-serif;
   }
 }

--- a/src/app/importar/page.tsx
+++ b/src/app/importar/page.tsx
@@ -181,7 +181,7 @@ export default function Page() {
                       </TableCell>
                       <TableCell>
                         <select
-                          className="h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm"
+                          className="h-9 w-full rounded-md border bg-background px-3 py-1 text-sm dark:bg-background dark:text-foreground"
                           value={row.tipo}
                           onChange={(e) => handleRowChange(i, 'tipo', e.target.value)}
                         >

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,10 +22,12 @@ export default function RootLayout({
         <link rel="manifest" href="/manifest.json" />
         <meta name="theme-color" content="#000000" />
       </head>
-      <body className={`${inter.variable} antialiased`}>
+      <body
+        className={`${inter.variable} min-h-screen bg-background text-foreground antialiased transition-colors dark:bg-background dark:text-foreground`}
+      >
         <Navbar />
         <Sidebar />
-        <div className="pt-14 lg:ml-64">{children}</div>
+        <main className="container mx-auto pt-14 lg:ml-64">{children}</main>
       </body>
     </html>
   );

--- a/src/app/transacoes/page.tsx
+++ b/src/app/transacoes/page.tsx
@@ -111,9 +111,9 @@ export default function Page() {
             <div>
               <Label>Tipo</Label>
               <select
-                className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
+                className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm dark:bg-background dark:text-foreground"
                 value={tipo}
-                onChange={(e) => setTipo(e.target.value as "receita" | "despesa")}
+                onChange={(e) => setTipo(e.target.value as 'receita' | 'despesa')}
               >
                 <option value="despesa">Despesa</option>
                 <option value="receita">Receita</option>
@@ -122,7 +122,7 @@ export default function Page() {
             <div>
               <Label>Categoria</Label>
               <select
-                className="mt-1 w-full rounded-md border px-3 py-2 text-sm"
+                className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm dark:bg-background dark:text-foreground"
                 value={categoriaId}
                 onChange={(e) => setCategoriaId(e.target.value)}
               >

--- a/src/components/navigation/navbar.tsx
+++ b/src/components/navigation/navbar.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { Menu } from 'lucide-react'
+import { ThemeToggle } from '@/components/theme-toggle'
 
 import { Button } from '@/components/ui/button'
 import { Sheet, SheetTrigger, SheetContent } from '@/components/ui/sheet'
@@ -21,7 +22,7 @@ export function Navbar() {
   const pathname = usePathname()
 
   return (
-    <header className="fixed inset-x-0 top-0 z-40 flex h-14 items-center border-b bg-background px-4 lg:ml-64">
+    <header className="fixed inset-x-0 top-0 z-40 flex h-14 items-center border-b bg-background px-4 transition-colors lg:ml-64 dark:bg-background dark:text-foreground">
       <Sheet>
         <SheetTrigger asChild className="lg:hidden">
           <Button variant="ghost" size="icon">
@@ -35,20 +36,23 @@ export function Navbar() {
       <Link href="/dashboard" className="ml-2 font-semibold">
         Controle Financeiro
       </Link>
-      <nav className="ml-auto hidden gap-4 lg:flex">
-        {links.map((link) => (
-          <Link
-            key={link.href}
-            href={link.href}
-            className={cn(
-              'text-sm transition-colors hover:text-primary',
-              pathname.startsWith(link.href) && 'font-semibold text-primary'
-            )}
-          >
-            {link.label}
-          </Link>
-        ))}
-      </nav>
+      <div className="ml-auto flex items-center gap-2">
+        <nav className="hidden gap-4 lg:flex">
+          {links.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={cn(
+                'text-sm transition-colors hover:text-primary',
+                pathname.startsWith(link.href) && 'font-semibold text-primary'
+              )}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+        <ThemeToggle />
+      </div>
     </header>
   )
 }

--- a/src/components/navigation/sidebar.tsx
+++ b/src/components/navigation/sidebar.tsx
@@ -42,7 +42,7 @@ export function Sidebar() {
   const pathname = usePathname()
 
   return (
-    <aside className="fixed inset-y-0 left-0 z-30 hidden w-64 border-r bg-background lg:block">
+    <aside className="fixed inset-y-0 left-0 z-30 hidden w-64 border-r bg-background transition-colors lg:block dark:bg-background dark:text-foreground">
       <SidebarLinks pathname={pathname} />
     </aside>
   )

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Moon, Sun } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>('dark')
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as 'light' | 'dark' | null
+    const initial = stored || 'dark'
+    setTheme(initial)
+    document.documentElement.classList.toggle('dark', initial === 'dark')
+  }, [])
+
+  function toggle() {
+    const next = theme === 'dark' ? 'light' : 'dark'
+    setTheme(next)
+    localStorage.setItem('theme', next)
+    document.documentElement.classList.toggle('dark', next === 'dark')
+  }
+
+  return (
+    <Button variant="ghost" size="icon" onClick={toggle} aria-label="Toggle theme">
+      {theme === 'dark' ? <Sun className="size-5" /> : <Moon className="size-5" />}
+    </Button>
+  )
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-background dark:text-foreground',
           className
         )}
         ref={ref}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -10,7 +10,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
     return (
       <select
         className={cn(
-          'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-background dark:text-foreground',
           className
         )}
         ref={ref}


### PR DESCRIPTION
## Summary
- enable dark mode globally with smooth transitions
- add theme toggle button in the navbar
- improve sidebar and navbar styling for dark mode
- update Input and Select components for dark theme support
- tweak form selects to inherit dark styles
- enhance layout container structure

## Testing
- `npx jest --config jest.config.js --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68445e29d7a083209426319890591a65