### PR TITLE
Fix jest config collision

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testMatch: ['**/__tests__/**/*.(test|spec).[jt]s?(x)']
+  testMatch: ['**/__tests__/**/*.(test|spec).[jt]s?(x)'],
+  testPathIgnorePatterns: ['/node_modules/']
 }

--- a/package.json
+++ b/package.json
@@ -7,14 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --ext .ts,.tsx --fix",
-    "test": "jest --passWithNoTests"
-  },
-  "jest": {
-    "preset": "ts-jest",
-    "testEnvironment": "node",
-    "testMatch": [
-      "**/__tests__/**/*.(test|spec).[jt]s?(x)"
-    ]
+    "test": "jest --passWithNoTests --config jest.config.js"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",


### PR DESCRIPTION
## Summary
- remove duplicate Jest config from package.json
- ignore node_modules while searching for tests
- run Jest with explicit config file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844605070dc8320ba946b1509bb470f